### PR TITLE
check clients for compatibility

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -490,6 +490,12 @@ void CClient::EnterGame()
 	// to finish the connection
 	SendEnterGame();
 	OnEnterGame();
+
+	// tell the server that i'm a netgui compatible client
+	CNetMsg_Cl_NetGui_TriggerEvent NGMsg;
+	NGMsg.m_Type = 1883;
+	NGMsg.m_ID = GAME_NETGUI_NUMERICVERSION;
+	SendPackMsg(&NGMsg, MSGFLAG_VITAL);
 }
 
 void CClient::Connect(const char *pAddress)

--- a/src/game/server/netgui.h
+++ b/src/game/server/netgui.h
@@ -38,10 +38,14 @@ public:
 	void OnClientDrop(int ClientID); // nah
 	void OnMessage(int MsgID, void *pRawMsg, int ClientID);
 
+	bool IsNetGuiClient(int ClientID) { return m_NetGuiClients[ClientID]; }
+
 protected:
 	CGameContext *GameServer() const { return m_pGameServer; }
 
 private:
+	bool m_NetGuiClients[MAX_CLIENTS]; // could have been put into CPlayer as well, but I want to keep stuff together
+
 	array<CNetMsg_Sv_NetGui_UIRect> m_UIRect[MAX_CLIENTS];
 	array<CNetMsg_Sv_NetGui_Label> m_Label[MAX_CLIENTS];
 	array<CNetMsg_Sv_NetGui_ButtonMenu> m_ButtonMenu[MAX_CLIENTS];

--- a/src/game/version.h
+++ b/src/game/version.h
@@ -6,5 +6,7 @@
 #define GAME_VERSION "0.7 trunk"
 //#define GAME_NETVERSION "0.7 " GAME_NETVERSION_HASH
 #define GAME_NETVERSION "0.7 be5937118401c37c"
+#define GAME_NETGUI_NUMERICVERSION 151222
+#define GAME_BUILD_DATE __DATE__ ", " __TIME__
 static const char GAME_RELEASE_VERSION[8] = {'0', '.', '6', '1', 0};
 #endif


### PR DESCRIPTION
- The server checks if the client has the ability to use NetGUI
- The server checks for the client's version of NetGUI

Not sure if this is good, though. Maybe a bit too much? Also, the client could check for updates himself instead... I did it serversided to warn the player about possible compatibility issues, but it's usually not the servers response, is it…?

Any thoughts?
